### PR TITLE
A few spectator changes

### DIFF
--- a/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/ClientSpectatingManager.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/ClientSpectatingManager.java
@@ -1,10 +1,13 @@
 package com.lovetropics.minigames.client.game.handler.spectate;
 
+import java.util.UUID;
+
 import com.lovetropics.minigames.Constants;
 import com.lovetropics.minigames.client.game.handler.ClientGameStateHandler;
 import com.lovetropics.minigames.common.core.game.client_state.instance.SpectatingClientState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.spectator.SpectatorGui;
+import net.minecraft.network.chat.TextColor;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.EntityViewRenderEvent;
 import net.minecraftforge.event.TickEvent;
@@ -39,6 +42,10 @@ public final class ClientSpectatingManager implements ClientGameStateHandler<Spe
 		if (session != null) {
 			session.close();
 		}
+	}
+
+	public void onPlayerActivity(UUID player, TextColor style) {
+		session.ui.onPlayerActivity(player, style);
 	}
 
 	@SubscribeEvent

--- a/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingState.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingState.java
@@ -30,6 +30,8 @@ interface SpectatingState {
 	default void applyToCamera(Minecraft client, SpectatingSession session, LocalPlayer player, Camera camera, float partialTicks, EntityViewRenderEvent.CameraSetup event) {
 	}
 
+	boolean allowsZoom();
+
 	class FreeCamera implements SpectatingState {
 		FreeCamera() {
 		}
@@ -55,6 +57,11 @@ interface SpectatingState {
 			}
 
 			return this;
+		}
+
+		@Override
+		public boolean allowsZoom() {
+			return false;
 		}
 	}
 
@@ -134,6 +141,11 @@ interface SpectatingState {
 				double distance = zoom * ClientSpectatingManager.MAX_CHASE_DISTANCE;
 				camera.move(-camera.getMaxZoom(distance), 0.0, 0.0);
 			}
+		}
+
+		@Override
+		public boolean allowsZoom() {
+			return true;
 		}
 
 		@Override

--- a/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
@@ -75,21 +75,21 @@ public final class SpectatingUi {
 			return;
 		}
 
-		if (InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LSHIFT) && InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LCONTROL)) {
-			return;
-		}
-
 		double delta = event.getScrollDelta();
-
-		boolean zoom = InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LCONTROL);
-		if (zoom) {
-			session.ui.onScrollZoom(delta);
-		} else {
-			session.ui.onScrollSelection(delta);
-		}
 
 		// Prevent adjusting the spectator fly speed
 		event.setCanceled(true);
+
+		if (!InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LCONTROL)) {
+			session.ui.onScrollSelection(delta);
+		} else {
+			if (session.state.allowsZoom()) {
+				session.ui.onScrollZoom(delta);
+			} else {
+				// Allow changing the fly speed
+				event.setCanceled(false);
+			}
+		}
 	}
 
 	private void onScrollZoom(double delta) {

--- a/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
@@ -77,6 +77,9 @@ public final class SpectatingUi {
 		} else {
 			session.ui.onScrollSelection(delta);
 		}
+
+		// Prevent adjusting the spectator fly speed
+		event.setCanceled(true);
 	}
 
 	private void onScrollZoom(double delta) {

--- a/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/spectate/SpectatingUi.java
@@ -75,6 +75,10 @@ public final class SpectatingUi {
 			return;
 		}
 
+		if (InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LSHIFT) && InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LCONTROL)) {
+			return;
+		}
+
 		double delta = event.getScrollDelta();
 
 		boolean zoom = InputConstants.isKeyDown(CLIENT.getWindow().getWindow(), InputConstants.KEY_LCONTROL);

--- a/src/main/java/com/lovetropics/minigames/common/core/game/behavior/GameBehaviorTypes.java
+++ b/src/main/java/com/lovetropics/minigames/common/core/game/behavior/GameBehaviorTypes.java
@@ -45,6 +45,7 @@ public class GameBehaviorTypes {
 	public static final GameBehaviorEntry<PermanentItemBehavior> PERMANENT_ITEM;
 	public static final GameBehaviorEntry<GeneralEventsTrigger> EVENTS;
 	public static final GameBehaviorEntry<OnDeathTrigger> ON_DEATH;
+	public static final GameBehaviorEntry<OnDamageTrigger> ON_DAMAGE;
 	public static final GameBehaviorEntry<WhileInRegionTrigger> WHILE_IN_REGION;
 	public static final GameBehaviorEntry<ScheduledActionsTrigger> SCHEDULED_ACTIONS;
 	public static final GameBehaviorEntry<PhaseChangeTrigger> PHASE_CHANGE;
@@ -116,6 +117,7 @@ public class GameBehaviorTypes {
 	public static final GameBehaviorEntry<TransformPlayerTornadoAction> TRANSFORM_PLAYER_TORNADO;
 	public static final GameBehaviorEntry<ChestDropAction> CHEST_DROP;
 	public static final GameBehaviorEntry<DamagePlayerAction> DAMAGE_PLAYER;
+	public static final GameBehaviorEntry<SpectatorActivityAction> SPECTATOR_ACTIVITY;
 
 	public static final GameBehaviorEntry<SetupTelemetryBehavior> SETUP_TELEMETRY;
 	public static final GameBehaviorEntry<AssignPlayerRolesBehavior> ASSIGN_PLAYER_ROLES;
@@ -175,6 +177,7 @@ public class GameBehaviorTypes {
 
 		EVENTS = register("events", GeneralEventsTrigger.CODEC);
 		ON_DEATH = register("on_death", OnDeathTrigger.CODEC);
+		ON_DAMAGE = register("on_damage", OnDamageTrigger.CODEC);
 		WHILE_IN_REGION = register("while_in_region", WhileInRegionTrigger.CODEC);
 		SCHEDULED_ACTIONS = register("scheduled_actions", ScheduledActionsTrigger.CODEC);
 		PHASE_CHANGE = register("phase_change", PhaseChangeTrigger.CODEC);
@@ -209,6 +212,7 @@ public class GameBehaviorTypes {
 		TRANSFORM_PLAYER_TORNADO = register("transform_player_tornado", TransformPlayerTornadoAction.CODEC);
 		CHEST_DROP = register("chest_drop", ChestDropAction.CODEC);
 		DAMAGE_PLAYER = register("damage_player", DamagePlayerAction.CODEC);
+		SPECTATOR_ACTIVITY = register("spectator_activity", SpectatorActivityAction.CODEC);
 
 		SETUP_TELEMETRY = register("setup_telemetry", SetupTelemetryBehavior.CODEC);
 		ASSIGN_PLAYER_ROLES = register("assign_player_roles", AssignPlayerRolesBehavior.CODEC);

--- a/src/main/java/com/lovetropics/minigames/common/core/game/behavior/instances/action/SpectatorActivityAction.java
+++ b/src/main/java/com/lovetropics/minigames/common/core/game/behavior/instances/action/SpectatorActivityAction.java
@@ -1,0 +1,28 @@
+package com.lovetropics.minigames.common.core.game.behavior.instances.action;
+
+import com.lovetropics.lib.codec.MoreCodecs;
+import com.lovetropics.minigames.common.core.game.GameException;
+import com.lovetropics.minigames.common.core.game.IGamePhase;
+import com.lovetropics.minigames.common.core.game.behavior.IGameBehavior;
+import com.lovetropics.minigames.common.core.game.behavior.event.EventRegistrar;
+import com.lovetropics.minigames.common.core.game.behavior.event.GameActionEvents;
+import com.lovetropics.minigames.common.core.network.LoveTropicsNetwork;
+import com.lovetropics.minigames.common.core.network.SpectatorPlayerActivityMessage;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.network.chat.TextColor;
+
+public record SpectatorActivityAction(TextColor style) implements IGameBehavior {
+    public static final Codec<SpectatorActivityAction> CODEC = RecordCodecBuilder.create(i -> i.group(
+            MoreCodecs.COLOR.fieldOf("style").forGetter(SpectatorActivityAction::style)
+    ).apply(i, SpectatorActivityAction::new));
+
+    @Override
+    public void register(IGamePhase game, EventRegistrar events) throws GameException {
+        events.listen(GameActionEvents.APPLY_TO_PLAYER, (context, target) -> {
+            game.getSpectators().sendPacket(LoveTropicsNetwork.CHANNEL, new SpectatorPlayerActivityMessage(target.getUUID(), style));
+            return true;
+        });
+    }
+}

--- a/src/main/java/com/lovetropics/minigames/common/core/game/behavior/instances/trigger/OnDamageTrigger.java
+++ b/src/main/java/com/lovetropics/minigames/common/core/game/behavior/instances/trigger/OnDamageTrigger.java
@@ -1,0 +1,26 @@
+package com.lovetropics.minigames.common.core.game.behavior.instances.trigger;
+
+import com.lovetropics.minigames.common.core.game.GameException;
+import com.lovetropics.minigames.common.core.game.IGamePhase;
+import com.lovetropics.minigames.common.core.game.behavior.IGameBehavior;
+import com.lovetropics.minigames.common.core.game.behavior.action.GameActionContext;
+import com.lovetropics.minigames.common.core.game.behavior.action.GameActionList;
+import com.lovetropics.minigames.common.core.game.behavior.event.EventRegistrar;
+import com.lovetropics.minigames.common.core.game.behavior.event.GamePlayerEvents;
+import com.mojang.serialization.Codec;
+
+import net.minecraft.world.InteractionResult;
+
+public record OnDamageTrigger(GameActionList actions) implements IGameBehavior {
+    public static final Codec<OnDamageTrigger> CODEC = GameActionList.CODEC.xmap(OnDamageTrigger::new, OnDamageTrigger::actions);
+
+    @Override
+    public void register(IGamePhase game, EventRegistrar events) throws GameException {
+        actions.register(game, events);
+
+        events.listen(GamePlayerEvents.DAMAGE, (player, damageSource, amount) -> {
+            actions.apply(game, GameActionContext.EMPTY, player);
+            return InteractionResult.PASS;
+        });
+    }
+}

--- a/src/main/java/com/lovetropics/minigames/common/core/network/LoveTropicsNetwork.java
+++ b/src/main/java/com/lovetropics/minigames/common/core/network/LoveTropicsNetwork.java
@@ -112,5 +112,10 @@ public final class LoveTropicsNetwork {
 				.encoder(DrawParticleLineMessage::encode).decoder(DrawParticleLineMessage::decode)
 				.consumer(DrawParticleLineMessage::handle)
 				.add();
+
+		CHANNEL.messageBuilder(SpectatorPlayerActivityMessage.class, 16, NetworkDirection.PLAY_TO_CLIENT)
+				.encoder(SpectatorPlayerActivityMessage::encode).decoder(SpectatorPlayerActivityMessage::decode)
+				.consumer(SpectatorPlayerActivityMessage::handle)
+				.add();
 	}
 }

--- a/src/main/java/com/lovetropics/minigames/common/core/network/SpectatorPlayerActivityMessage.java
+++ b/src/main/java/com/lovetropics/minigames/common/core/network/SpectatorPlayerActivityMessage.java
@@ -1,0 +1,31 @@
+package com.lovetropics.minigames.common.core.network;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import com.lovetropics.minigames.client.game.handler.spectate.ClientSpectatingManager;
+
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.TextColor;
+import net.minecraftforge.network.NetworkEvent;
+
+public record SpectatorPlayerActivityMessage(UUID player, TextColor style) {
+    public void encode(FriendlyByteBuf buffer) {
+        buffer.writeUUID(player);
+        // The longest colour name is 12 characters, so only leave a small bit of headway in our length assumption
+        buffer.writeUtf(style.serialize(), 16);
+    }
+
+    public static SpectatorPlayerActivityMessage decode(FriendlyByteBuf buffer) {
+        UUID player = buffer.readUUID();
+        TextColor style = TextColor.parseColor(buffer.readUtf(16));
+        return new SpectatorPlayerActivityMessage(player, style);
+    }
+
+    public void handle(Supplier<NetworkEvent.Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+            ClientSpectatingManager.INSTANCE.onPlayerActivity(player, style);
+        });
+        ctx.get().setPacketHandled(true);
+    }
+}


### PR DESCRIPTION
- Don't adjust fly speed when scrolling through spectator menu
- New behaviour for temporarily highlighting interesting players to spectators (`ltminigames:spectator_activity`). Based off this:
  ![image](https://user-images.githubusercontent.com/87578678/199842139-439192cb-12d4-44f7-98f1-4efc86fbe9cc.png)
  I felt having the list shuffle round all the time could make it difficult to select a specific player, so instead games can have the image of the face flash and fades with the colour configured in the behaviour for 500ms. (example: LoveTropics/LTDatapack#5)
