### PR TITLE
Fix health text not rendering (Closes #291)

### DIFF
--- a/src/main/java/com/lovetropics/minigames/client/game/handler/HealthTagRenderer.java
+++ b/src/main/java/com/lovetropics/minigames/client/game/handler/HealthTagRenderer.java
@@ -79,7 +79,11 @@ public final class HealthTagRenderer {
 
 		float textX = (left + iconSize) * textScale;
 		float textY = -font.lineHeight / 2.0F;
+		poseStack.pushPose();
+		poseStack.scale(-1, 1, 1);
+		poseStack.translate(-16, 0, 0);
 		font.drawInBatch(healthText, textX, textY, CommonColors.WHITE, false, poseStack.last().pose(), bufferSource, Font.DisplayMode.NORMAL, 0, LightTexture.FULL_BRIGHT);
+		poseStack.popPose();
 
 		poseStack.pushPose();
 		poseStack.translate(left - 4.5f, -4.5F, 0.0F);


### PR DESCRIPTION
The x of the PoseStack was inverted causing the text to refuse to render